### PR TITLE
Switch from block install to per-pkg install

### DIFF
--- a/.github/workflows/install-rsyslog-packages-from-ppa.yml
+++ b/.github/workflows/install-rsyslog-packages-from-ppa.yml
@@ -86,22 +86,50 @@ jobs:
       - name: Restart rsyslog
         run: sudo service rsyslog restart
 
-      - name: Install additional PPA-provided packages
-        run: |
-          sudo apt-get install rsyslog-kafka
-          sudo apt-get install rsyslog-doc
-          sudo apt-get install rsyslog-mysql
-          sudo apt-get install rsyslog-pgsql
-          sudo apt-get install rsyslog-relp
-          sudo apt-get install rsyslog-elasticsearch
-          sudo apt-get install rsyslog-mmjsonparse
-          sudo apt-get install rsyslog-imptcp
-          sudo apt-get install rsyslog-mmnormalize
-          sudo apt-get install rsyslog-mmanon
-          sudo apt-get install rsyslog-mmfields
-          sudo apt-get install rsyslog-mmutf8fix
-          sudo apt-get install rsyslog-utils
-          sudo apt-get install rsyslog-mmrm1stspace
+      - name: systemctl status output
+        run: sudo systemctl status rsyslog
+
+      - name: Install rsyslog-kafka
+        run: sudo apt-get install rsyslog-kafka
+
+      - name: Install rsyslog-doc
+        run: sudo apt-get install rsyslog-doc
+
+      - name: Install rsyslog-mysql
+        run: sudo apt-get install rsyslog-mysql
+
+      - name: Install rsyslog-pgsql
+        run: sudo apt-get install rsyslog-pgsql
+
+      - name: Install rsyslog-relp
+        run: sudo apt-get install rsyslog-relp
+
+      - name: Install rsyslog-elasticsearch
+        run: sudo apt-get install rsyslog-elasticsearch
+
+      - name: Install rsyslog-mmjsonparse
+        run: sudo apt-get install rsyslog-mmjsonparse
+
+      - name: Install rsyslog-imptcp
+        run: sudo apt-get install rsyslog-imptcp
+
+      - name: Install rsyslog-mmnormalize
+        run: sudo apt-get install rsyslog-mmnormalize
+
+      - name: Install rsyslog-mmanon
+        run: sudo apt-get install rsyslog-mmanon
+
+      - name: Install rsyslog-mmfields
+        run: sudo apt-get install rsyslog-mmfields
+
+      - name: Install rsyslog-mmutf8fix
+        run: sudo apt-get install rsyslog-mmutf8fix
+
+      - name: Install rsyslog-utils
+        run: sudo apt-get install rsyslog-utils
+
+      - name: Install rsyslog-mmrm1stspace
+        run: sudo apt-get install rsyslog-mmrm1stspace
 
   enable_daily_stable_ppa_and_install_packages:
     name: Enable daily stable PPA and install packages


### PR DESCRIPTION
Each installation occurs via a separate process, so the thought
is that this would make spotting a specific failure quicker as
the output would be separated based on the installation of a
specific package.

Note: This set of changes is for the "Scheduled Stable PPA" job. The "daily stable PPA" job is left as-is for now for contrast.