### PR TITLE
Reorder install cmds, separate out into separate steps

### DIFF
--- a/.github/workflows/install-rsyslog-packages-from-ppa.yml
+++ b/.github/workflows/install-rsyslog-packages-from-ppa.yml
@@ -93,20 +93,11 @@ jobs:
       - name: Install rsyslog-doc
         run: sudo apt-get install rsyslog-doc
 
-      - name: Install rsyslog-mysql
-        run: sudo apt-get install rsyslog-mysql
-
-      - name: Install rsyslog-pgsql
-        run: sudo apt-get install rsyslog-pgsql
-
       - name: Install rsyslog-relp
         run: sudo apt-get install rsyslog-relp
 
       - name: Install rsyslog-elasticsearch
         run: sudo apt-get install rsyslog-elasticsearch
-
-      - name: Install rsyslog-mmjsonparse
-        run: sudo apt-get install rsyslog-mmjsonparse
 
       - name: Install rsyslog-imptcp
         run: sudo apt-get install rsyslog-imptcp
@@ -128,6 +119,15 @@ jobs:
 
       - name: Install rsyslog-mmrm1stspace
         run: sudo apt-get install rsyslog-mmrm1stspace
+
+      - name: Install rsyslog-pgsql
+        run: sudo apt-get install rsyslog-pgsql
+
+      - name: Install rsyslog-mysql
+        run: sudo apt-get install rsyslog-mysql
+
+      - name: Install rsyslog-mmjsonparse
+        run: sudo apt-get install rsyslog-mmjsonparse
 
       - name: Display installed rsyslog packages
         run: dpkg -l | grep -E 'rsyslog|adiscon'
@@ -184,22 +184,64 @@ jobs:
       - name: systemctl status output
         run: sudo systemctl status rsyslog
 
-      - name: Install additional PPA-provided packages
-        run: |
-          sudo apt-get install rsyslog-kafka
-          sudo apt-get install rsyslog-doc
-          sudo apt-get install rsyslog-mysql
-          sudo apt-get install rsyslog-pgsql
-          sudo apt-get install rsyslog-relp
-          sudo apt-get install rsyslog-elasticsearch
-          sudo apt-get install rsyslog-mmjsonparse
-          sudo apt-get install rsyslog-imptcp
-          sudo apt-get install rsyslog-mmnormalize
-          sudo apt-get install rsyslog-mmanon
-          sudo apt-get install rsyslog-mmfields
-          sudo apt-get install rsyslog-mmutf8fix
-          sudo apt-get install rsyslog-utils
-          sudo apt-get install rsyslog-mmrm1stspace
+      # - name: Install additional PPA-provided packages
+      #   run: |
+      #     sudo apt-get install rsyslog-kafka
+      #     sudo apt-get install rsyslog-doc
+      #     sudo apt-get install rsyslog-mysql
+      #     sudo apt-get install rsyslog-pgsql
+      #     sudo apt-get install rsyslog-relp
+      #     sudo apt-get install rsyslog-elasticsearch
+      #     sudo apt-get install rsyslog-mmjsonparse
+      #     sudo apt-get install rsyslog-imptcp
+      #     sudo apt-get install rsyslog-mmnormalize
+      #     sudo apt-get install rsyslog-mmanon
+      #     sudo apt-get install rsyslog-mmfields
+      #     sudo apt-get install rsyslog-mmutf8fix
+      #     sudo apt-get install rsyslog-utils
+      #     sudo apt-get install rsyslog-mmrm1stspace
+
+      - name: Install rsyslog-kafka
+        run: sudo apt-get install rsyslog-kafka
+
+      - name: Install rsyslog-doc
+        run: sudo apt-get install rsyslog-doc
+
+      - name: Install rsyslog-relp
+        run: sudo apt-get install rsyslog-relp
+
+      - name: Install rsyslog-elasticsearch
+        run: sudo apt-get install rsyslog-elasticsearch
+
+      - name: Install rsyslog-imptcp
+        run: sudo apt-get install rsyslog-imptcp
+
+      - name: Install rsyslog-mmnormalize
+        run: sudo apt-get install rsyslog-mmnormalize
+
+      - name: Install rsyslog-mmanon
+        run: sudo apt-get install rsyslog-mmanon
+
+      - name: Install rsyslog-mmfields
+        run: sudo apt-get install rsyslog-mmfields
+
+      - name: Install rsyslog-mmutf8fix
+        run: sudo apt-get install rsyslog-mmutf8fix
+
+      - name: Install rsyslog-utils
+        run: sudo apt-get install rsyslog-utils
+
+      - name: Install rsyslog-mmrm1stspace
+        run: sudo apt-get install rsyslog-mmrm1stspace
+
+      - name: Install rsyslog-pgsql
+        run: sudo apt-get install rsyslog-pgsql
+
+      - name: Install rsyslog-mysql
+        run: sudo apt-get install rsyslog-mysql
+
+      - name: Install rsyslog-mmjsonparse
+        run: sudo apt-get install rsyslog-mmjsonparse
 
       - name: Display installed rsyslog packages
         run: dpkg -l | grep -E 'rsyslog|adiscon'


### PR DESCRIPTION
- Move the packages which seemed to fail for Ubuntu 20.04 towards the bottom of the list (maybe the top would have been better?)
- Separate out remaining install commands "block" into separate commands to make troubleshooting easier