### PR TITLE
Attempt to allow other jobs to continue when Ubuntu 20.04 fails

### DIFF
--- a/.github/workflows/install-rsyslog-packages-from-ppa.yml
+++ b/.github/workflows/install-rsyslog-packages-from-ppa.yml
@@ -38,15 +38,23 @@ jobs:
   enable_scheduled_stable_ppa_and_install_packages:
     name: Enable scheduled stable PPA and install packages
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     # Default: 360 minutes
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         # Explicitly list supported LTS versions
         # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
         # Note: 'ubuntu-latest' currently maps to 'ubuntu-18.04'
         #os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        experimental: [false]
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        include:
+          # attempt to set Ubuntu 20.04 as experimental so it doesn't "fail
+          # the build" and stop all other job variations from running
+          - os: ubuntu-20.04
+            experimental: true
 
     steps:
       - name: Install stock Ubuntu-provided rsyslog


### PR DESCRIPTION
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error